### PR TITLE
prevent text selection behavior

### DIFF
--- a/client/src/components/PosterStack/index.js
+++ b/client/src/components/PosterStack/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSprings } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
 import PropTypes from 'prop-types'
@@ -56,6 +56,15 @@ const PosterStack = ({
       const dirX = xDir < 0 ? -1 : 1
       const dirY = yDir < 0 ? -1 : 1
       const swipeThreshold = isPhoneWide ? 20 : 150
+
+      // Prevent default text-selection behavior on mobile devices
+      // while the user is swiping a card.
+      // See https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting
+      if (isDown) {
+        document.body.classList.add('unselectable')
+      } else {
+        document.body.classList.remove('unselectable')
+      }
 
       if (!isDown && trigger) gone.add(index)
       const isGone = gone.has(index)

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,3 +21,13 @@ code {
   font-family: 'bevan';
   src: local('Bevan-Regular'), url('./fonts/Bevan-Regular.ttf');
 }
+
+.unselectable {
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Old versions of Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Edge, Opera and Firefox */
+}


### PR DESCRIPTION
- [ ] Adds a custom class that completely negates any text selection behavior
- [ ] Apply this class to the document.body when the user is pressing down on a card